### PR TITLE
Update summary field

### DIFF
--- a/includes/TripalFields/local__germ_ril_summary/local__germ_ril_summary.inc
+++ b/includes/TripalFields/local__germ_ril_summary/local__germ_ril_summary.inc
@@ -132,6 +132,7 @@ class local__germ_ril_summary extends TripalField {
       $args = array();
       $args[':F1'] = $gen['F1']; $args[':F2'] = $gen['F2']; $args[':F3'] = $gen['F3']; $args[':F4'] = $gen['F4'];
       $args[':F5'] = $gen['F5']; $args[':F6'] = $gen['F6']; $args[':F7'] = $gen['F7']; $args[':F8'] = $gen['F8'];
+
       $args[':RIL_complete'] = $gen['RIL_complete'];
 
       $args[':is_mom'] = variable_get('gs_var_ismom');
@@ -140,59 +141,58 @@ class local__germ_ril_summary extends TripalField {
 
       $args[':stock_id'] = $entity->chado_record_id;
 
-
       // Fs and Parents.
-      $f = chado_query("
+      $sql = "
         SELECT
-            s.stock_id,
-            mom.name AS maternal_parent, mom.type_id AS mom_type,
-            dad.name AS paternal_parent, dad.type_id AS dad_type,
+          s.stock_id,
+          mom.name AS maternal_parent, mom.stock_id AS mom_id, mom.type_id AS mom_type,
+          dad.name AS paternal_parent, dad.stock_id AS dad_id, dad.type_id AS dad_type,
+          STRING_AGG(
+            CASE
+              WHEN prop.type_id = :F1 THEN CONCAT('F1=>', TRIM(prop.value))
+              WHEN prop.type_id = :F2 THEN CONCAT('F2=>', TRIM(prop.value))
+              WHEN prop.type_id = :F3 THEN CONCAT('F3=>', TRIM(prop.value))
+              WHEN prop.type_id = :F4 THEN CONCAT('F4=>', TRIM(prop.value))
+              WHEN prop.type_id = :F5 THEN CONCAT('F5=>', TRIM(prop.value))
+              WHEN prop.type_id = :F6 THEN CONCAT('F6=>', TRIM(prop.value))
+              WHEN prop.type_id = :F7 THEN CONCAT('F7=>', TRIM(prop.value))
+              WHEN prop.type_id = :F8 THEN CONCAT('F8=>', TRIM(prop.value))
+              ELSE ''
+            END, ' # ') AS property_generation,
+          STRING_AGG(CASE WHEN prop.type_id = :RIL_complete THEN TRIM( prop.value ) END, '') AS property_complete
+        FROM {stock} s
+          LEFT JOIN {organism} o ON o.organism_id=s.organism_id
 
-            STRING_AGG(
-              CASE
-                WHEN prop.type_id = :F1 THEN CONCAT('F1=>', TRIM(prop.value))
-                WHEN prop.type_id = :F2 THEN CONCAT('F2=>', TRIM(prop.value))
-                WHEN prop.type_id = :F3 THEN CONCAT('F3=>', TRIM(prop.value))
-                WHEN prop.type_id = :F4 THEN CONCAT('F4=>', TRIM(prop.value))
-                WHEN prop.type_id = :F5 THEN CONCAT('F5=>', TRIM(prop.value))
-                WHEN prop.type_id = :F6 THEN CONCAT('F6=>', TRIM(prop.value))
-                WHEN prop.type_id = :F7 THEN CONCAT('F7=>', TRIM(prop.value))
-                WHEN prop.type_id = :F8 THEN CONCAT('F8=>', TRIM(prop.value))
-                ELSE ''
-              END, ' # ') AS property_generation,
-            STRING_AGG(CASE WHEN prop.type_id = :RIL_complete THEN TRIM( prop.value ) END, '') AS property_complete
-          FROM {stock} s
-            LEFT JOIN {organism} o ON o.organism_id=s.organism_id
+          LEFT JOIN {stock_relationship} origcross ON origcross.subject_id=s.stock_id
+            AND origcross.type_id = :is_sel
+          LEFT JOIN {stock_relationship} momr ON momr.object_id=origcross.object_id
+            AND momr.type_id=:is_mom
+          LEFT JOIN {stock_relationship} dadr ON dadr.object_id=origcross.object_id
+            AND dadr.type_id=:is_dad
 
-            LEFT JOIN {stock_relationship} origcross ON origcross.subject_id=s.stock_id
-              AND origcross.type_id = :is_sel
-            LEFT JOIN {stock_relationship} momr ON momr.object_id=origcross.object_id
-              AND momr.type_id=:is_mom
-            LEFT JOIN {stock_relationship} dadr ON dadr.object_id=origcross.object_id
-              AND dadr.type_id=:is_dad
+          LEFT JOIN {stock} mom ON momr.subject_id=mom.stock_id
+          LEFT JOIN {stock} dad ON dadr.subject_id=dad.stock_id
+          LEFT JOIN {organism} momo ON momo.organism_id=mom.organism_id
+          LEFT JOIN {organism} dado ON dado.organism_id=dad.organism_id
 
-            LEFT JOIN {stock} mom ON momr.subject_id=mom.stock_id
-            LEFT JOIN {stock} dad ON dadr.subject_id=dad.stock_id
-            LEFT JOIN {organism} momo ON momo.organism_id=mom.organism_id
-            LEFT JOIN {organism} dado ON dado.organism_id=dad.organism_id
+          LEFT JOIN {stockprop} AS prop ON s.stock_id = prop.stock_id
+        WHERE s.stock_id = :stock_id
+        GROUP BY
+          s.stock_id, mom.name, mom.uniquename, mom.stock_id, mom.type_id,
+          dad.name, dad.uniquename, dad.stock_id, dad.type_id";
 
-            LEFT JOIN {stockprop} AS prop ON s.stock_id = prop.stock_id
-          WHERE s.stock_id  = :stock_id
-          GROUP BY
-            s.stock_id, mom.name, mom.type_id, dad.name, dad.type_id", $args
-        )
-      ->fetchObject();
+      $f = chado_query($sql, $args)
+        ->fetchObject();
 
       if ($f) {
-        // Debug values:
-        // $germ_ril_summary['all'] = $f;
-
-        $germ_ril_summary['maternal']    = $f->maternal_parent;
+        $germ_ril_summary['maternal']      = $f->maternal_parent;
         $germ_ril_summary['mom_entity_id'] = grs_get_stock_entity_id($f->mom_id, $f->mom_type);
-        $germ_ril_summary['paternal']    = $f->paternal_parent;
+
+        $germ_ril_summary['paternal']      = $f->paternal_parent;
         $germ_ril_summary['dad_entity_id'] = grs_get_stock_entity_id($f->dad_id, $f->dad_type);
-        $germ_ril_summary['complete']    = $f->property_complete;
-        $germ_ril_summary['generations'] = $f->property_generation;
+        $germ_ril_summary['complete']      = $f->property_complete;
+
+        $germ_ril_summary['generations']   = $f->property_generation;
       }
     }
 

--- a/includes/TripalFields/local__germ_ril_summary/local__germ_ril_summary.inc
+++ b/includes/TripalFields/local__germ_ril_summary/local__germ_ril_summary.inc
@@ -124,59 +124,63 @@ class local__germ_ril_summary extends TripalField {
       'complete' => '',
     );
 
-    // Some relationships.
-    // F prperties
-    $prop = chado_query("
-      SELECT t2.name, t2.cvterm_id
-      FROM {cv} AS t1 INNER JOIN {cvterm} AS t2 USING(cv_id)
-      WHERE
-        t2.name IN ('F1', 'F2', 'F3', 'F4', 'F5', 'F6', 'F7', 'F8', 'RIL_complete')
-        AND t1.name = 'stock_property'")
-    ->fetchAllKeyed();
+    // Ontology terms required prepared by the summary component in hook_install of this module.
+    // F generations.
+    $gen = unserialize(variable_get('gs_var_fgens'));
 
-    if ($prop) {
+    if ($gen) {
+      $args = array();
+      $args[':F1'] = $gen['F1']; $args[':F2'] = $gen['F2']; $args[':F3'] = $gen['F3']; $args[':F4'] = $gen['F4'];
+      $args[':F5'] = $gen['F5']; $args[':F6'] = $gen['F6']; $args[':F7'] = $gen['F7']; $args[':F8'] = $gen['F8'];
+      $args[':RIL_complete'] = $gen['RIL_complete'];
+
+      $args[':is_mom'] = variable_get('gs_var_ismom');
+      $args[':is_dad'] = variable_get('gs_var_isdad');
+      $args[':is_sel'] = variable_get('gs_var_issel');
+
+      $args[':stock_id'] = $entity->chado_record_id;
+
+
       // Fs and Parents.
-      $f = chado_query("SELECT child.stock_id,
-        mom.name AS maternal_parent,
-        mom.stock_id AS mom_id, mom.type_id AS mom_type,
+      $f = chado_query("
+        SELECT
+            s.stock_id,
+            mom.name AS maternal_parent, mom.type_id AS mom_type,
+            dad.name AS paternal_parent, dad.type_id AS dad_type,
 
-        dad.name AS paternal_parent,
-        dad.stock_id AS dad_id, dad.type_id AS dad_type,
+            STRING_AGG(
+              CASE
+                WHEN prop.type_id = :F1 THEN CONCAT('F1=>', TRIM(prop.value))
+                WHEN prop.type_id = :F2 THEN CONCAT('F2=>', TRIM(prop.value))
+                WHEN prop.type_id = :F3 THEN CONCAT('F3=>', TRIM(prop.value))
+                WHEN prop.type_id = :F4 THEN CONCAT('F4=>', TRIM(prop.value))
+                WHEN prop.type_id = :F5 THEN CONCAT('F5=>', TRIM(prop.value))
+                WHEN prop.type_id = :F6 THEN CONCAT('F6=>', TRIM(prop.value))
+                WHEN prop.type_id = :F7 THEN CONCAT('F7=>', TRIM(prop.value))
+                WHEN prop.type_id = :F8 THEN CONCAT('F8=>', TRIM(prop.value))
+                ELSE ''
+              END, ' # ') AS property_generation,
+            STRING_AGG(CASE WHEN prop.type_id = :RIL_complete THEN TRIM( prop.value ) END, '') AS property_complete
+          FROM {stock} s
+            LEFT JOIN {organism} o ON o.organism_id=s.organism_id
 
-        STRING_AGG(
-          CASE WHEN prop.type_id = :RIL_complete THEN TRIM(prop.value)
-          END, '') AS property_complete,
-        STRING_AGG(
-          CASE
-            WHEN prop.type_id = :F1 THEN CONCAT('F1=>', TRIM(prop.value))
-            WHEN prop.type_id = :F2 THEN CONCAT('F2=>', TRIM(prop.value))
-            WHEN prop.type_id = :F3 THEN CONCAT('F3=>', TRIM(prop.value))
-            WHEN prop.type_id = :F4 THEN CONCAT('F4=>', TRIM(prop.value))
-            WHEN prop.type_id = :F5 THEN CONCAT('F5=>', TRIM(prop.value))
-            WHEN prop.type_id = :F6 THEN CONCAT('F6=>', TRIM(prop.value))
-            WHEN prop.type_id = :F7 THEN CONCAT('F7=>', TRIM(prop.value))
-            WHEN prop.type_id = :F8 THEN CONCAT('F8=>', TRIM(prop.value))
-            ELSE ''
-          END, '#') AS property_generation
-      FROM
-        {stock} child
-        LEFT JOIN {stock_relationship} srm ON srm.object_id = child.stock_id AND
-          srm.type_id = (SELECT cvterm_id FROM {cvterm} WHERE name = 'is_maternal_parent_of')
-        LEFT JOIN {stock} mom ON srm.subject_id = mom.stock_id
+            LEFT JOIN {stock_relationship} origcross ON origcross.subject_id=s.stock_id
+              AND origcross.type_id = :is_sel
+            LEFT JOIN {stock_relationship} momr ON momr.object_id=origcross.object_id
+              AND momr.type_id=:is_mom
+            LEFT JOIN {stock_relationship} dadr ON dadr.object_id=origcross.object_id
+              AND dadr.type_id=:is_dad
 
-        LEFT JOIN {stock_relationship} srd ON srd.object_id = child.stock_id AND
-          srd.type_id = (SELECT cvterm_id FROM {cvterm} WHERE name = 'is_paternal_parent_of')
-        LEFT JOIN {stock} dad ON srd.subject_id = dad.stock_id
+            LEFT JOIN {stock} mom ON momr.subject_id=mom.stock_id
+            LEFT JOIN {stock} dad ON dadr.subject_id=dad.stock_id
+            LEFT JOIN {organism} momo ON momo.organism_id=mom.organism_id
+            LEFT JOIN {organism} dado ON dado.organism_id=dad.organism_id
 
-        LEFT JOIN {stockprop} AS prop ON child.stock_id = prop.stock_id
-      WHERE child.stock_id = :stock_id
-      GROUP BY child.stock_id, mom.name, mom.uniquename, mom.stock_id, mom.type_id,
-        dad.name, dad.type_id, dad.uniquename, dad.stock_id",
-      array(
-        ':stock_id' => $entity->chado_record_id,
-        ':F1'  => $prop['F1'], ':F2'  => $prop['F2'], ':F3'  => $prop['F3'], ':F4'  => $prop['F4'],
-        ':F5'  => $prop['F5'], ':F6'  => $prop['F6'], ':F7'  => $prop['F7'], ':F8'  => $prop['F8'],
-        ':RIL_complete' => $prop['RIL_complete']))
+            LEFT JOIN {stockprop} AS prop ON s.stock_id = prop.stock_id
+          WHERE s.stock_id  = :stock_id
+          GROUP BY
+            s.stock_id, mom.name, mom.type_id, dad.name, dad.type_id", $args
+        )
       ->fetchObject();
 
       if ($f) {

--- a/includes/TripalFields/local__germ_ril_summary/local__germ_ril_summary_formatter.inc
+++ b/includes/TripalFields/local__germ_ril_summary/local__germ_ril_summary_formatter.inc
@@ -63,7 +63,7 @@ class local__germ_ril_summary_formatter extends TripalFieldFormatter {
     foreach($f as $g) {
       if (!empty($g)) {
         @list($f_gen, $f_val) = explode('=>', $g);
-        $generations_value[$f_gen] = $f_val;
+        $generations_value[ trim($f_gen) ] = $f_val;
       }
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- No need to include the issue number in the title :-) -->
This PR is an update to the query to show F generations and parents of a stock to match the query used in generating the matrix and stock list in this module.
## Metadata
<!--- If it fixes an open issue, please add the issue link below. -->
 - Issue https://github.com/UofS-Pulse-Binfo/germ_summary/issues/15 Incorrect parent in RIL summary field

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I feel this PR is ready to be merged.
- [X] This PR is dependent upon [PR #14]
https://github.com/UofS-Pulse-Binfo/germ_summary/pull/14 Incorrect Parent (Matrix)

Documentation:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

## Dependencies
<!-- If this code is dependent upon another module and/or PR, 
       state that here. -->
<!-- Include information about other modules/PRs needed for testing,
        which to enable/merge first, etc. -->
This PR is dependent upon the most recent version of hook_install available in the PR#14 mentioned above.

## Testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how
      your change affects other areas of the code, etc. -->
<!--- Reviewers will use this section to test the submission! -->
If you have not done so, Ensure to update this module in your KP instance by uninstalling first, then update germplasm summary with the most recent version. Reinstall/enable the module and clear cache.
- [ ] I tested on a generic Tripal Site
- [X] I tested on a KnowPulse Clone
- [ ] This PR includes automated testing
